### PR TITLE
Performance improvments - fixes #10

### DIFF
--- a/src/mapsets.erl
+++ b/src/mapsets.erl
@@ -25,6 +25,7 @@
         , from_list/1
         , add_element/2
         , intersection/2
+        , size/1
         ]).
 
 -export_type([ set/0
@@ -72,6 +73,11 @@ add_element(E, #mapset{map = Map}) ->
 intersection(#mapset{map = Map1}, #mapset{map = Map2}) ->
   {MapA, MapB} = order_by_size(Map1, Map2),
   #mapset{map = maps:with(maps:keys(MapA), MapB)}.
+
+%% @doc given set, returns it's size
+-spec size(set()) -> integer().
+size(#mapset{map = Map}) ->
+  map_size(Map).
 
 -spec order_by_size(sets_map(E), sets_map(E)) -> {sets_map(E), sets_map(E)}.
 order_by_size(Map1, Map2) when map_size(Map1) > map_size(Map2) -> {Map2, Map1};

--- a/src/mapsets.erl
+++ b/src/mapsets.erl
@@ -1,0 +1,78 @@
+%%% @doc set implementation using maps.
+%%%
+%%% Copyright X4lldux 2017 &lt;x4lldux@vectron.io&gt;
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%% @end
+%%% @copyright X4lldux <x4lldux@vectron.io>
+%%%
+-module(mapsets).
+-author("X4lldux <x4lldux@vectron.io>").
+
+%% API
+-export([ new/0
+        , to_list/1
+        , from_list/1
+        , add_element/2
+        , intersection/2
+        ]).
+
+-export_type([ set/0
+             , set/1
+             ]).
+
+%% Define a set with maps.
+-record(mapset,
+        {map=#{}                 :: sets_map()      % Number of elements
+        }).
+
+-type sets_map() :: sets_map(_).
+-type sets_map(E) :: #{ E => nil() }.
+
+-type set() :: set(_).
+-opaque set(Element) :: #mapset{map :: sets_map(Element)}.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc returns new set
+-spec new() -> set().
+new() ->
+  #mapset{}.
+
+%% @doc given a set, returns a list of elements
+-spec to_list(set(E)) -> list(E).
+to_list(#mapset{map=Map}) ->
+  maps:keys(Map).
+
+%% @doc given a list, returns a set
+-spec from_list(list(E)) -> set(E).
+from_list(L) ->
+  Map = maps:from_list([{E, []} || E <- L]),
+  #mapset{map = Map}.
+
+%% @doc adds an element to a set
+-spec add_element(E, set(E)) -> set(E).
+add_element(E, #mapset{map = Map}) ->
+  #mapset{map = Map#{ E => [] }}.
+
+%% @doc given two sets, returns their intersection
+-spec intersection(set(E), set(E)) -> set(E).
+intersection(#mapset{map = Map1}, #mapset{map = Map2}) ->
+  {MapA, MapB} = order_by_size(Map1, Map2),
+  #mapset{map = maps:with(maps:keys(MapA), MapB)}.
+
+-spec order_by_size(sets_map(E), sets_map(E)) -> {sets_map(E), sets_map(E)}.
+order_by_size(Map1, Map2) when map_size(Map1) > map_size(Map2) -> {Map2, Map1};
+order_by_size(Map1, Map2) -> {Map1, Map2}.

--- a/src/sheldon_dictionary.erl
+++ b/src/sheldon_dictionary.erl
@@ -163,12 +163,12 @@ fill_ets(EtsName, Source) ->
   {ok, SourceBin} = file:read_file(Source),
   Words = re:split(SourceBin, "\n"), % one word per line
   ok = create_ets(EtsName),
-  [ets:insert(EtsName, {Word}) || Word <- Words],
+  ets:insert(EtsName, [{Word} || Word <- Words]),
   Words.
 
 -spec create_ets(atom()) -> ok.
 create_ets(EtsName) ->
-  EtsName = ets:new(EtsName, [named_table, {read_concurrency, true}]),
+  EtsName = ets:new(EtsName, [named_table, duplicate_bag, {read_concurrency, true}]),
   ok.
 
 %%%===================================================================

--- a/src/sheldon_dictionary.erl
+++ b/src/sheldon_dictionary.erl
@@ -188,10 +188,10 @@ candidates(WordStr, Lang) ->
 know_sets(Word, [], _Lang) ->
   [Word];
 know_sets(Word, [Set | Sets], Lang) ->
-  EmptySet = empty_set(),
-  case know(Set, Lang) of
-    EmptySet -> know_sets(Word, Sets, Lang);
-    Words    -> mapsets:to_list(Words)
+  Words = know(Set, Lang),
+  case mapsets:size(Words) of
+    0 -> know_sets(Word, Sets, Lang);
+    _ -> mapsets:to_list(Words)
   end.
 
 -spec know(mapsets:set(), language()) -> mapsets:set().

--- a/src/sheldon_dictionary.erl
+++ b/src/sheldon_dictionary.erl
@@ -136,7 +136,7 @@ learn_language(Lang) ->
   Words = fill_ets(DictionaryName, LangSource),
 
   % save the keys in set format in order to suggest words
-  KeysSet = sets:from_list(Words),
+  KeysSet = mapsets:from_list(Words),
   ets:insert(DictionaryName, {keys, KeysSet}),
   ok.
 
@@ -178,26 +178,26 @@ create_ets(EtsName) ->
 -spec candidates(string(), language()) -> [string()].
 candidates(WordStr, Lang) ->
   Word = list_to_binary(string:to_lower(WordStr)),
-  Set1 = sets:add_element(Word, empty_set()),
-  Set2 = sets:from_list(edits1(Word)),
-  Set3 = sets:from_list(edits2(Word)),
+  Set1 = mapsets:add_element(Word, empty_set()),
+  Set2 = mapsets:from_list(edits1(Word)),
+  Set3 = mapsets:from_list(edits2(Word)),
   Candidates = know_sets(Word, [Set1, Set2, Set3], Lang),
   [binary_to_list(Bin) || Bin <- Candidates].
 
--spec know_sets(binary(), [sets:set()], language()) -> [binary()].
+-spec know_sets(binary(), [mapsets:set()], language()) -> [binary()].
 know_sets(Word, [], _Lang) ->
   [Word];
 know_sets(Word, [Set | Sets], Lang) ->
   EmptySet = empty_set(),
   case know(Set, Lang) of
     EmptySet -> know_sets(Word, Sets, Lang);
-    Words    -> sets:to_list(Words)
+    Words    -> mapsets:to_list(Words)
   end.
 
--spec know(sets:set(), language()) -> sets:set().
+-spec know(mapsets:set(), language()) -> mapsets:set().
 know(WordsSet, Lang) ->
   [{keys, KeysSet}] = ets:lookup(dictionary_name(Lang), keys),
-  sets:intersection(WordsSet, KeysSet).
+  mapsets:intersection(WordsSet, KeysSet).
 
 -spec edits1(binary()) -> [binary()].
 edits1(WordBinary) ->
@@ -241,6 +241,6 @@ edits2(Word) ->
 chars() ->
   "abcdefghijklmnopqrstuvwxyz".
 
--spec empty_set() -> sets:set().
+-spec empty_set() -> mapsets:set().
 empty_set() ->
-  sets:new().
+  mapsets:new().


### PR DESCRIPTION
By moving to maps based set implementation, performance is improved significantly.
current implementation:
 - loads in ~37s, 
 - spellchecking in ~1.7s (tested on included romeo & juliet example)

my implementation:
 - loads in ~1.1s (yes, that's a 37x faster)
 - spellchecking in ~0.8s (same test)

It also fixes a bug in generation of candidates and finds more of them.
Because you are matching on an empty set, which is an opaque type and can have many internal representations of an empty set, current implementation sometimes returns an empty list of candidates instead calling the catch-all case, which would return a one element list with the checked word. Whether returning the same word as a candidate makes any sens, is out of scope.

I also have a second implementation in a `binary_dict` branch, which can dump ETS table to a binary file, and when loading dictionary tries to populate ETS from it. This reduces loading to ~0.4s.